### PR TITLE
Add holiday aware working days

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased][unreleased]
-- No changes that affect gem usage as of yet.
+### Fixed
+- The date format error message now contains the correct spelling of "ambiguous".
 
 ## [0.2.0][0.2.0] - 2016-06-23
 ### Changed (breaking changes)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased][unreleased]
+### Changed
+- Generators are configured with `direction` and not `choose`.
+
 ### Fixed
 - The date format error message now contains the correct spelling of "ambiguous".
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file. This change
 ## [Unreleased][unreleased]
 ### Added
 - `:working_day` generator can now optionally take a `holidays: []` array for additional non-working days.
+- Integration tests that also double as examples.
 
 ### Changed
 - Generators are configured with `direction` and not `choose`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased][unreleased]
+### Added
+- `:working_day` generator can now optionally take a `holidays: []` array for additional non-working days.
+
 ### Changed
 - Generators are configured with `direction` and not `choose`.
 

--- a/README.md
+++ b/README.md
@@ -9,16 +9,15 @@ The current version is [![Gem Version](https://badge.fury.io/rb/upcoming.svg)](h
 
 ## Examples
 
-`Upcoming::Factory.every` will generate sequences using the given method. This uses an enumerator so any number of dates can be queried.
+`Upcoming::Factory.every` will return an infinite sequence that is defined by the generators called.
+
+Please find the integration test examples in [`spec/integration_spec.rb`](spec/integration_spec.rb).
 
 ```ruby
 # running on 20th of June, 2014
 > factory = Upcoming::Factory.every(:last_day_of_month)
 => #<Upcoming::Factory:0xb8ba6838 @options={:from=>#<Date: 2014-06-20 ((2456829j,0s,0n),+0s,2299161j)>},
      @chain=[#<Upcoming::LastDayOfMonthGenerator:0xb8ba6310 @choose=:first>]>
-
-> factory.first
-=> #<Date: 2014-06-30 ((2456839j,0s,0n),+0s,2299161j)>
 
 > factory.take(12).map(&:iso8601)
 => ["2014-06-30", "2014-07-31", "2014-08-31", "2014-09-30", "2014-10-31", "2014-11-30",
@@ -57,6 +56,9 @@ Upcoming::Factory.every(:last_day_of_month, from: '2014-06-20')
   .take(3).map(&:iso8601)
 => ["2014-06-30", "2014-07-31", "2014-09-01"]
 ```
+
+This is due to the current implementation, which only moves dates when "generators" do not "match" the date being tested.
+Ie. if the date being tested is a Monday, all 3 "working day" generators will say "yes, it's a working day" and will not attempt to find another date.
 
 ## Generators
 

--- a/lib/upcoming/factory.rb
+++ b/lib/upcoming/factory.rb
@@ -49,7 +49,7 @@ module Upcoming
     def create_generator(name, direction)
       class_name = name.to_s.classify + 'Generator'
       generator_class = Upcoming.const_get class_name
-      generator_class.new(choose: direction)
+      generator_class.new(direction: direction)
     end
   end
 end

--- a/lib/upcoming/factory.rb
+++ b/lib/upcoming/factory.rb
@@ -48,8 +48,8 @@ module Upcoming
 
     def create_generator(name, direction)
       class_name = name.to_s.classify + 'Generator'
-      generator_class = Upcoming.const_get class_name
-      generator_class.new(direction: direction)
+      generator_class = Upcoming.const_get(class_name)
+      generator_class.new(@options.merge(direction: direction))
     end
   end
 end

--- a/lib/upcoming/factory.rb
+++ b/lib/upcoming/factory.rb
@@ -40,7 +40,7 @@ module Upcoming
       options[:from] ||= Date.today
       if options[:from].is_a? String
         iso = options[:from] =~ /\d{4}-\d{2}-\d{2}/
-        raise ArgumentError, 'Please use ISO dates (YYYY-MM-DD) as those are not ambigious.' unless iso
+        raise ArgumentError, 'Please use ISO dates (YYYY-MM-DD) as those are not ambiguous.' unless iso
       end
       options[:from] = options[:from].to_date if options[:from].respond_to? :to_date
       options

--- a/lib/upcoming/generators/generator.rb
+++ b/lib/upcoming/generators/generator.rb
@@ -1,9 +1,9 @@
 module Upcoming
   class Generator
-    attr_reader :choose
+    attr_reader :direction
 
     def initialize(options = {})
-      @choose = options.fetch(:choose, :upcoming)
+      @direction = options.fetch(:direction, :upcoming)
     end
 
     def step(from)
@@ -13,7 +13,7 @@ module Upcoming
     private
 
     def date_range(date)
-      return date.downto(date.prev_year) if choose == :preceding
+      return date.downto(date.prev_year) if direction == :preceding
       date.upto(date.next_year)
     end
   end

--- a/lib/upcoming/generators/working_day_generator.rb
+++ b/lib/upcoming/generators/working_day_generator.rb
@@ -2,8 +2,20 @@ module Upcoming
   class WorkingDayGenerator < Generator
     WEEKDAYS = (1..5)
 
-    def valid?(date)
-      WEEKDAYS.include? date.wday
+    def initialize(options = {})
+      super(options)
+      @holidays = options.fetch(:holidays, []).map { |date|
+        date.is_a?(String) ? Date.parse(date) : date
+      }
     end
+
+    def valid?(date)
+      return false if holidays.include?(date)
+      WEEKDAYS.include?(date.wday)
+    end
+
+    private
+
+    attr_reader :holidays
   end
 end

--- a/spec/factory_spec.rb
+++ b/spec/factory_spec.rb
@@ -84,4 +84,22 @@ describe Upcoming::Factory do
       end
     end
   end
+
+  context 'configured generators' do
+    class Upcoming::DivisibleByNDayGenerator < Upcoming::Generator
+      def initialize(options = {})
+        super(options)
+        @n = options.fetch(:n, 1)
+      end
+
+      def valid?(date)
+        date.day % @n == 0
+      end
+    end
+
+    context 'passes configuration to the generators' do
+      Given(:subject) { Upcoming::Factory.every(:divisible_by_n_day, n: 2) }
+      Then { result == %w(2014-06-16 2014-06-18 2014-06-20) }
+    end
+  end
 end

--- a/spec/factory_spec.rb
+++ b/spec/factory_spec.rb
@@ -52,7 +52,7 @@ describe Upcoming::Factory do
 
       context 'generates error if given as non-ISO date' do
         Given(:date) { '01/05/2014' }
-        Then { result == Failure(ArgumentError, /Please use ISO dates \(YYYY-MM-DD\) as those are not ambigious/) }
+        Then { result == Failure(ArgumentError, /Please use ISO dates \(YYYY-MM-DD\) as those are not ambiguous/) }
       end
     end
   end

--- a/spec/generators/generator_spec.rb
+++ b/spec/generators/generator_spec.rb
@@ -30,7 +30,7 @@ describe Upcoming::Generator do
   end
 
   context 'forward in time' do
-    Given(:subject) { Upcoming::FakeGenerator.new(choose: :upcoming) }
+    Given(:subject) { Upcoming::FakeGenerator.new(direction: :upcoming) }
 
     returns_the_starting_date_if_it_is_valid
 
@@ -51,7 +51,7 @@ describe Upcoming::Generator do
   end
 
   context 'backward in time' do
-    Given(:subject) { Upcoming::FakeGenerator.new(choose: :preceding) }
+    Given(:subject) { Upcoming::FakeGenerator.new(direction: :preceding) }
 
     returns_the_starting_date_if_it_is_valid
 

--- a/spec/generators/working_day_generator_spec.rb
+++ b/spec/generators/working_day_generator_spec.rb
@@ -24,4 +24,15 @@ describe Upcoming::WorkingDayGenerator do
     Then { subject.valid?(thursday) }
     Then { subject.valid?(friday) }
   end
+
+  context 'with a set of non-working days configured' do
+    Given(:good_friday) { Date.parse('2018-03-30') }
+    Given(:easter_monday) { Date.parse('2018-04-02') }
+    Given(:subject) { Upcoming::WorkingDayGenerator.new(holidays: [good_friday, easter_monday]) }
+
+    Then { subject.valid?(good_friday - 1) }
+    Then { !subject.valid?(good_friday) }
+    Then { !subject.valid?(easter_monday) }
+    Then { subject.valid?(easter_monday + 1) }
+  end
 end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+describe 'working_day' do
+  Given(:f) { Upcoming::Factory }
+
+  context 'finding the next working day after a Friday' do
+    # 2018-08-03 is a Friday: the next working day is Monday, 6th
+    Then { Date.parse('2018-08-06') ==
+           f.every(:working_day, from: '2018-08-03').first }
+  end
+
+  context 'finding the next non-holiday working day' do
+    # 2018-08-24 is a Friday, Monday 27th is a holiday: next working day is Tuesday, 28th
+    Then { Date.parse('2018-08-28') ==
+           f.every(:working_day, from: '2018-08-24', holidays: ['2018-08-27']).first }
+  end
+
+  context 'finding the working day preceding the last day of the month' do
+    # The last day of August 2014 was a Sunday, 31st August 2014.
+    # The nearest preceding working day was Friday, 29th.
+    Then { Date.parse('2014-08-29') ==
+           f.every(:last_day_of_month, from: '2014-08-20').then_find_preceding(:working_day).first }
+  end
+
+  context 'finding the first working day at or after the end of the month' do
+    # The last day of July 2014 was a Thursday, 31st July 2014
+    # The upcoming working day is the same day
+    Then { Date.parse('2014-07-31') ==
+           f.every(:last_day_of_month, from: '2014-07-20').then_find_upcoming(:working_day).first }
+
+    # The last day of August 2014 was a Sunday, 31st August 2014
+    # The upcoming working day after that was Monday, 1st September 2014
+    Then { Date.parse('2014-09-01') ==
+           f.every(:last_day_of_month, from: '2014-08-20').then_find_upcoming(:working_day).first }
+  end
+end


### PR DESCRIPTION
## What does this pull request do?

Adds `holidays: []` configuration to the `:working_day` generator.

Currently, this is not that helpful as every day has to be added by hand. In the future, some presets could be created with this scaffolding, eg. for [UK bank holidays in England and Wales](https://www.gov.uk/bank-holidays.json).

## Any additional changes that would benefit highlighting?

- Fixed the spelling of "ambiguous".
- Clarified that "generators" are configured with "direction" (for the flow of time), not "choose".